### PR TITLE
修复 PHP SDK 部分接口 asyncNotify 等方法无效问题

### DIFF
--- a/php/src/Kernel/EasySDKKernel.php
+++ b/php/src/Kernel/EasySDKKernel.php
@@ -400,16 +400,16 @@ class EasySDKKernel
 
     private function addOtherParams($textParams, $bizParams)
     {
-        if ($this->optionalTextParams == null) {
+        if ($this->optionalTextParams === null) {
             $this->textParams = $textParams;
         }
-        if ($textParams != null && $this->optionalTextParams != null) {
+        if ($textParams !== null && $this->optionalTextParams !== null) {
             $this->textParams = array_merge($textParams, $this->optionalTextParams);
         }
-        if ($this->optionalBizParams == null) {
+        if ($this->optionalBizParams === null) {
             $this->bizParams = $bizParams;
         }
-        if ($bizParams != null && $this->optionalBizParams != null) {
+        if ($bizParams !== null && $this->optionalBizParams !== null) {
             $this->bizParams = array_merge($bizParams, $this->optionalBizParams);
         }
     }


### PR DESCRIPTION
#106 

在 PHP SDK 的每个接口调用方法中，只要 $textParams 为空数组（[]）时，都会导致调用 $this->_kernel->injectTextParam() 该方法设置的参数不起作用，比如 asyncNotify。

主要是 EasySDKKernel.php 中 406 行的代码导致：
`
        if ($textParams != null && $this->optionalTextParams != null) {
            $this->textParams = array_merge($textParams, $this->optionalTextParams);
        }
`

因为在 PHP 中 [] == null 为 true，导致设置的 optionalTextParams 不会被 merge 进来，故需要改为强类型值判断。