### PR TITLE
[php]fix获取小程序用户信息异常，toJsonString参数报错

### DIFF
--- a/php/src/Kernel/EasySDKKernel.php
+++ b/php/src/Kernel/EasySDKKernel.php
@@ -365,7 +365,7 @@ class EasySDKKernel
         }
         if ($bizParams != null && $this->optionalBizParams != null) {
             $this->bizParams = array_merge($bizParams, $this->optionalBizParams);
-        } else if ($bizParams == null) {
+        } else if ($bizParams == null && $this->optionalBizParams != null) {
             $this->bizParams = $this->optionalBizParams;
         }
         $json = new JsonUtil();


### PR DESCRIPTION
获取小程序用户信息异常，调用代码如下：
```
Factory::base()->oauth()->getToken($code)
```
提示Argument 1 passed to Alipay\EasySDK\Kernel\Util\JsonUtil::toJsonString() must be of the type array, null given, called in vendor/alipaysdk/easysdk/php/src/Kernel/EasySDKKernel.php on line 372



