### PR TITLE
modify payment.trade.page.pay default method to support GET method to…

### DIFF
--- a/php/src/Payment/Page/Client.php
+++ b/php/src/Payment/Page/Client.php
@@ -19,9 +19,10 @@ class Client {
      * @param string $outTradeNo
      * @param string $totalAmount
      * @param string $returnUrl
+     * @param string $method
      * @return AlipayTradePagePayResponse
      */
-    public function pay($subject, $outTradeNo, $totalAmount, $returnUrl){
+    public function pay($subject, $outTradeNo, $totalAmount, $returnUrl, $method = 'POST'){
         $systemParams = [
             "method" => "alipay.trade.page.pay",
             "app_id" => $this->_kernel->getConfig("appId"),
@@ -45,7 +46,7 @@ class Client {
         ];
         $sign = $this->_kernel->sign($systemParams, $bizParams, $textParams, $this->_kernel->getConfig("merchantPrivateKey"));
         $response = [
-            "body" => $this->_kernel->generatePage("POST", $systemParams, $bizParams, $textParams, $sign)
+            "body" => $this->_kernel->generatePage($method, $systemParams, $bizParams, $textParams, $sign)
         ];
         return AlipayTradePagePayResponse::fromMap($response);
     }


### PR DESCRIPTION
设置调用支付模块生成支付请求相关信息默认请求方式，默认使用POST方式生成交易表单，渲染后自动跳转支付宝网站引导用户完成支付，同时支持用户传入GET方式，生成获取跳转链接。