### PR TITLE
Fix Deprecated in PHP 7.4

### DIFF
--- a/php/src/Kernel/Util/AntCertificationUtil.php
+++ b/php/src/Kernel/Util/AntCertificationUtil.php
@@ -72,7 +72,7 @@ class AntCertificationUtil
     {
         $dec = 0;
         $len = strlen($hex);
-        for ($i = 1; $i <= $len; $i++) {
+        for ($i = 3; $i <= $len; $i++) {
             $dec = bcadd($dec, bcmul(strval(hexdec($hex[$i - 1])), bcpow('16', strval($len - $i))));
         }
         return $dec;


### PR DESCRIPTION
`$i` 为 1 的情况下，是把 `0x` 两个字符都去做了一次计算，在低版本没问题。

在 PHP 7.4 下就会报 Deprecated 错误