### PR TITLE
fix: php >=7.4 Deprecated

### DIFF
--- a/php/src/Kernel/Util/AntCertificationUtil.php
+++ b/php/src/Kernel/Util/AntCertificationUtil.php
@@ -72,7 +72,7 @@ class AntCertificationUtil
     {
         $dec = 0;
         $len = strlen($hex);
-        for ($i = 1; $i <= $len; $i++) {
+        for ($i = (false === strpos(strtolower($hex), '0x') ? 1 : 3); $i <= $len; $i++) {
             $dec = bcadd($dec, bcmul(strval(hexdec($hex[$i - 1])), bcpow('16', strval($len - $i))));
         }
         return $dec;


### PR DESCRIPTION
`PHP Deprecated:  Invalid characters passed for attempted conversion, these have been ignored`