### PR TITLE
fix: 使在外部可以通过Factory实例访问到kernel

### DIFF
--- a/php/src/Kernel/Factory.php
+++ b/php/src/Kernel/Factory.php
@@ -46,13 +46,13 @@ class Factory
             $config->alipayPublicKey = $certEnvironment->getCachedAlipayPublicKey();
         }
 
-        $kernel = new EasySDKKernel($config);
-        self::$base = new Base($kernel);
-        self::$marketing = new Marketing($kernel);
-        self::$member = new Member($kernel);
-        self::$payment = new Payment($kernel);
-        self::$security = new Security($kernel);
-        self::$util = new Util($kernel);
+        $this->kernel = new EasySDKKernel($config);
+        self::$base = new Base($this->kernel);
+        self::$marketing = new Marketing($this->kernel);
+        self::$member = new Member($this->kernel);
+        self::$payment = new Payment($this->kernel);
+        self::$security = new Security($this->kernel);
+        self::$util = new Util($this->kernel);
     }
 
     public static function setOptions($config)

--- a/php/src/Util/Generic/Client.php
+++ b/php/src/Util/Generic/Client.php
@@ -306,4 +306,31 @@ class Client {
         return $this;
     }
 
+    /**
+     * 生成页面类请求所需URL或Form表单
+     * @param string $method 接口名称，如：ant.merchant.expand.indirect.zft.consult
+     * @param array $bizParams 业务参数（OpenAPI中biz_content里的参数）
+     * @param array $textParams 公共请求参数（OpenAPI中非biz_content里的参数）
+     * @param string $httpMethod 生成的请求类型，GET生成URL, POST生成HTML表单（自动执行表单POST请求）
+     * @return object AlipayOpenApiGenericSDKResponse
+     */
+    public function generatePage($method, $bizParams = [], $textParams = [], $httpMethod = 'POST')
+    {
+        $systemParams = [
+            'method' => $method,
+            'app_id' => $this->_kernel->getConfig('appId'),
+            'timestamp' => $this->_kernel->getTimestamp(),
+            'format' => 'json',
+            'version' => '1.0',
+            'alipay_sdk' => $this->_kernel->getSdkVersion(),
+            'charset' => 'UTF-8',
+            'sign_type' => $this->_kernel->getConfig('signType'),
+            'app_cert_sn' => $this->_kernel->getMerchantCertSN(),
+            'alipay_root_cert_sn' => $this->_kernel->getAlipayRootCertSN()
+        ];
+        $sign = $this->_kernel->sign($systemParams, $bizParams, $textParams, $this->_kernel->getConfig('merchantPrivateKey'));
+        $response = ['body' => $this->_kernel->generatePage($httpMethod, $systemParams, $bizParams, $textParams, $sign)];
+        return AlipayOpenApiGenericSDKResponse::fromMap($response);
+    }
+
 }


### PR DESCRIPTION
修复Factory类中的$kernel未被赋值的bug。
使在SDK外部可以通过Factory实例访问到kernel，这样在SDK外部够访问到EasySDKKernel的generatePage方法。支付宝直付通中好几个接口需要用到generatePage方法，但SDK没有对外暴露generatePage（有bug）.
修改原因：原来的Factory类中的$kernel属性没有被赋值，一直处于null状态，无法调用。下面是修改后，在SDK外部某个类方法中调用$kernel的示例 (摘抄)：

```
$this->sdk = Factory::setOptions(self::getOptions());
$systemParams = [
            'method' => $method,
            'app_id' => $this->sdk->kernel->getConfig('appId'),
            'timestamp' => $this->sdk->kernel->getTimestamp(),
            'format' => 'json',
            'version' => '1.0',
            'alipay_sdk' => $this->sdk->kernel->getSdkVersion(),
            'charset' => 'UTF-8',
            'sign_type' => $this->sdk->kernel->getConfig('signType'),
            'app_cert_sn' => $this->sdk->kernel->getMerchantCertSN(),
            'alipay_root_cert_sn' => $this->sdk->kernel->getAlipayRootCertSN()
];
$sign = $this->sdk->kernel->sign($systemParams, $bizParams, $textParams, $this->sdk->kernel->getConfig('merchantPrivateKey'));
return ['body' => $this->sdk->kernel->generatePage($httpMethod, $systemParams, $bizParams, $textParams, $sign)];
```
