### PR TITLE
feat: 增加通用的generatePage方法，直付通模式合并支付请求付款时需要此方法

### DIFF
--- a/php/src/Kernel/Factory.php
+++ b/php/src/Kernel/Factory.php
@@ -46,13 +46,13 @@ class Factory
             $config->alipayPublicKey = $certEnvironment->getCachedAlipayPublicKey();
         }
 
-        $kernel = new EasySDKKernel($config);
-        self::$base = new Base($kernel);
-        self::$marketing = new Marketing($kernel);
-        self::$member = new Member($kernel);
-        self::$payment = new Payment($kernel);
-        self::$security = new Security($kernel);
-        self::$util = new Util($kernel);
+        $this->kernel = new EasySDKKernel($config);
+        self::$base = new Base($this->kernel);
+        self::$marketing = new Marketing($this->kernel);
+        self::$member = new Member($this->kernel);
+        self::$payment = new Payment($this->kernel);
+        self::$security = new Security($this->kernel);
+        self::$util = new Util($this->kernel);
     }
 
     public static function setOptions($config)

--- a/php/src/Util/Generic/Client.php
+++ b/php/src/Util/Generic/Client.php
@@ -306,4 +306,31 @@ class Client {
         return $this;
     }
 
+    /**
+     * 生成页面类请求所需URL或Form表单
+     * @param string $method 接口名称，如：ant.merchant.expand.indirect.zft.consult
+     * @param array $bizParams 业务参数（OpenAPI中biz_content里的参数）
+     * @param array $textParams 公共请求参数（OpenAPI中非biz_content里的参数）
+     * @param string $httpMethod 生成的请求类型，GET生成URL, POST生成HTML表单（自动执行表单POST请求）
+     * @return object AlipayOpenApiGenericSDKResponse
+     */
+    public function generatePage($method, $bizParams = [], $textParams = [], $httpMethod = 'POST')
+    {
+        $systemParams = [
+            'method' => $method,
+            'app_id' => $this->_kernel->getConfig('appId'),
+            'timestamp' => $this->_kernel->getTimestamp(),
+            'format' => 'json',
+            'version' => '1.0',
+            'alipay_sdk' => $this->_kernel->getSdkVersion(),
+            'charset' => 'UTF-8',
+            'sign_type' => $this->_kernel->getConfig('signType'),
+            'app_cert_sn' => $this->_kernel->getMerchantCertSN(),
+            'alipay_root_cert_sn' => $this->_kernel->getAlipayRootCertSN()
+        ];
+        $sign = $this->_kernel->sign($systemParams, $bizParams, $textParams, $this->_kernel->getConfig('merchantPrivateKey'));
+        $response = ['body' => $this->_kernel->generatePage($httpMethod, $systemParams, $bizParams, $textParams, $sign)];
+        return AlipayOpenApiGenericSDKResponse::fromMap($response);
+    }
+
 }


### PR DESCRIPTION
理由1：
支付宝-直付通模式-合并支付接口 alipay.trade.wap.merge.pay(无线Wap合并支付接口2.0)，需要使用generatePage生成POST表单，但是SDK没有对外暴露generatePage方法，导致easy版SDK调用alipay.trade.wap.merge.pay非常麻烦，不easy！

增加方法后，alipay.trade.wap.merge.pay 调用示例如下：

```
$response = Factory::util()->generic()->generatePage('alipay.trade.wap.merge.pay', ['pre_order_no' => $preOrderNo]);
return $response->toMap();
```

理由2：
`Factory::payment()->wap()->pay()` 方法写死了只能时生成POST表单，不能生成GET链接返回给前端跳转，如果有通用的generatePage方法，灵活度提升很多。

